### PR TITLE
Minor fixes for docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ COPY lib /usr/src/app/lib/
 COPY web /usr/src/app/web/
 COPY *.js /usr/src/app/
 RUN npm install
+RUN npm run gulp
 
 RUN apk del make gcc g++ python && rm -rf /tmp/* /root/.npm /root/.node-gyp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ WORKDIR /usr/src/app
 COPY package.json /usr/src/app/
 COPY lib /usr/src/app/lib/
 COPY web /usr/src/app/web/
-COPY tasks /usr/src/app/tasks/
 COPY *.js /usr/src/app/
 RUN npm install
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "postinstall": "cd web && bower install",
     "test": "npm run lint-lib && node_modules/.bin/karma start --single-run",
     "jshint-check": "grunt build",
-    "lint-lib": "./node_modules/.bin/semistandard ./lib/*/*.js"
+    "lint-lib": "./node_modules/.bin/semistandard ./lib/*/*.js",
+    "gulp": "./node_modules/.bin/gulp"
   },
   "pre-commit": [
     "jshint-check",


### PR DESCRIPTION
* Remove the installation of the `tasks/` directory
* Add a gulp run during the build

As discussed offline, the gulp run actually makes the build fail due to linting errors.